### PR TITLE
3.0/fix/event import cron

### DIFF
--- a/event-manager-integration.php
+++ b/event-manager-integration.php
@@ -60,17 +60,20 @@ $acfExportManager->autoExport(array(
 ));
 $acfExportManager->import();
 
-add_filter( '/Modularity/externalViewPath', function($arr) 
-    {
-        $arr['mod-event-submit'] = EVENTMANAGERINTEGRATION_SUBMIT_FORM_MODULE_VIEW_PATH;
-        $arr['mod-event'] = EVENTMANAGERINTEGRATION_MODULE_VIEW_PATH;
-        return $arr;
-    }, 10, 3
+add_filter(
+    '/Modularity/externalViewPath',
+    function ($arr) {
+    $arr['mod-event-submit'] = EVENTMANAGERINTEGRATION_SUBMIT_FORM_MODULE_VIEW_PATH;
+    $arr['mod-event'] = EVENTMANAGERINTEGRATION_MODULE_VIEW_PATH;
+    return $arr;
+},
+    10,
+    3
 );
 
 // Activation & deactivation hooks
-register_activation_hook(plugin_basename(__FILE__), '\EventManagerIntegration\App::addCronJob');
-register_deactivation_hook(plugin_basename(__FILE__), '\EventManagerIntegration\App::removeCronJob');
+register_activation_hook(plugin_basename(__FILE__), '\EventManagerIntegration\Cron::addCronJob');
+register_deactivation_hook(plugin_basename(__FILE__), '\EventManagerIntegration\Cron::removeCronJob');
 
 // Create database table when plugin is activated
 register_activation_hook(plugin_basename(__FILE__), '\EventManagerIntegration\Install::createTables');

--- a/source/php/Admin/Options.php
+++ b/source/php/Admin/Options.php
@@ -19,6 +19,7 @@ class Options
         add_action('wp_ajax_save_draw_points', array($this, 'saveDrawPoints'));
         add_action('acf/render_field/type=message', array($this, 'renderAcfField'), 11, 1);
         add_filter('acf/update_value/name=event_import_from_location', array($this, 'updateLocationOption'), 10, 1);
+        add_filter('acf/update_value/name=event_daily_import', array($this, 'updateCronOption'), 10, 1);
     }
 
     /**
@@ -42,6 +43,20 @@ class Options
     {
         if ($value != 'area') {
             update_option('event_import_area', null);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Unregister cron event when option is disabled
+     * @param  string $value   the value of the field
+     * @return string          the new value
+     */
+    public function updateCronOption($value)
+    {
+        if (!$value) {
+            \EventManagerIntegration\Cron::removeCronJob();
         }
 
         return $value;

--- a/source/php/App.php
+++ b/source/php/App.php
@@ -12,10 +12,8 @@ class App
         add_action('wp_enqueue_scripts', array($this, 'enqueueFront'), 950);
         add_action('admin_enqueue_scripts', array($this, 'enqueueAdmin'));
 
-        /* Register cron action */
-        add_action('import_events_daily', array($this, 'importEventsCron'));
-
         new Install();
+        new Cron();
         new Api\Events();
         new OAuth\OAuthAdmin();
         new OAuth\OAuthRequests();
@@ -66,7 +64,7 @@ class App
     {
         // If child theme is active, insert plugin view path after child views path.
         if (is_child_theme()) {
-            array_splice( $array, 2, 0, array(EVENTMANAGERINTEGRATION_VIEW_PATH) );
+            array_splice($array, 2, 0, array(EVENTMANAGERINTEGRATION_VIEW_PATH));
         } else {
             // Add view path first in the list if child theme is not active.
             array_unshift($array, EVENTMANAGERINTEGRATION_VIEW_PATH);
@@ -82,8 +80,10 @@ class App
     public function enqueueAdmin()
     {
         // Styles
-        wp_register_style('event-integration-admin',
-            EVENTMANAGERINTEGRATION_URL . '/dist/' . Helper\CacheBust::name('css/event-manager-integration-admin.css'));
+        wp_register_style(
+            'event-integration-admin',
+            EVENTMANAGERINTEGRATION_URL . '/dist/' . Helper\CacheBust::name('css/event-manager-integration-admin.css')
+        );
         wp_enqueue_style('event-integration-admin');
 
         // Scripts
@@ -114,7 +114,8 @@ class App
         // Styles
         wp_enqueue_style(
             'event-integration',
-            EVENTMANAGERINTEGRATION_URL . '/dist/' . Helper\CacheBust::name('css/event-manager-integration.css'));
+            EVENTMANAGERINTEGRATION_URL . '/dist/' . Helper\CacheBust::name('css/event-manager-integration.css')
+        );
 
         // Scripts
 
@@ -189,36 +190,15 @@ class App
     }
 
     /**
-     * Start cron jobs
-     * @return void
-     */
-    public function importEventsCron()
-    {
-        if (get_field('event_daily_import', 'option') == true && $apiUrl = Helper\ApiUrl::buildApiUrl()) {
-            new Parser\EventManagerApi($apiUrl);
-        }
-    }
-
-    public static function addCronJob()
-    {
-        wp_schedule_event(time(), 'hourly', 'import_events_daily');
-    }
-
-    public static function removeCronJob()
-    {
-        wp_clear_scheduled_hook('import_events_daily');
-    }
-
-    /**
      * Import publishing groups from Event Manager API
      * @return void
      */
     public static function importPublishingGroups()
     {
-        $api_url = get_field('event_api_url', 'option');
-        if ($api_url) {
-            $api_url = rtrim($api_url, '/') . '/user_groups';
-            new Parser\EventManagerGroups($api_url);
+        $apiUrl = get_field('event_api_url', 'option');
+        if ($apiUrl) {
+            $apiUrl = rtrim($apiUrl, '/') . '/user_groups';
+            new Parser\EventManagerGroups($apiUrl);
         }
     }
 }

--- a/source/php/Cron.php
+++ b/source/php/Cron.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace EventManagerIntegration;
+
+class Cron
+{
+    public static $cronJobName = 'import_events_daily';
+
+    public function __construct()
+    {
+        add_action('import_events_daily', array($this, 'importEventsCron'));
+        add_action('admin_init', array($this, 'checkCronActivation'));
+    }
+
+    public static function addCronJob()
+    {
+        wp_schedule_event(time(), 'hourly', self::$cronJobName);
+    }
+
+    public static function removeCronJob()
+    {
+        wp_clear_scheduled_hook(self::$cronJobName);
+    }
+
+    /**
+     * Start cron jobs
+     * @return void
+     */
+    public function importEventsCron()
+    {
+        $apiUrl = Helper\ApiUrl::buildApiUrl();
+        if (get_field('event_daily_import', 'option') == true && $apiUrl) {
+            new Parser\EventManagerApi($apiUrl);
+        }
+    }
+
+    /**
+     * Checks if cron is registered and reschedules if it's missing
+     * @return void
+     */
+    public function checkCronActivation()
+    {
+        global $pagenow;
+        if (wp_doing_ajax()
+            || !get_field('event_daily_import', 'option')
+            || !('edit.php' === $pagenow && isset($_GET['post_type']) && 'event' === $_GET['post_type'])
+          ) {
+            return;
+        }
+
+        $cronJobs = get_option('cron');
+        $isCronRegistered = false;
+        foreach ($cronJobs as $cronGroups) {
+            if (is_array($cronGroups) && array_key_exists(self::$cronJobName, $cronGroups)) {
+                $isCronRegistered = true;
+            }
+        }
+
+        if (!$isCronRegistered) {
+            // Remove any duplicates and reschedule cron
+            self::removeCronJob();
+            self::addCronJob();
+        }
+    }
+}


### PR DESCRIPTION
Duct tape fix that solves problem with cron jobs that is randomly removed.

- Solution: Added a check (checkCronActivation) on every time user enters admin page and navigates to post type event, then it will double check if cron option is checked and if cron is still registered. If cron is missing in the list it will reschedule automatically.  
- Moved all cron methods to a new Cron class
- Also added fix to remove the cron job when option is disabled. 