### PR TITLE
3.0/fix/remove history function when translating

### DIFF
--- a/source/js/Module/Event/Components/FilterableEventsContainer.js
+++ b/source/js/Module/Event/Components/FilterableEventsContainer.js
@@ -122,8 +122,7 @@ class FilterableEventsContainer extends React.Component {
         categories: categoryIds,
         tags: tagIds,
         ageRange: ageRangeIds,
-      },
-      { pushState: true }
+      }
     );
       if(params.translate){
         location.hash = "#translate";
@@ -157,7 +156,9 @@ class FilterableEventsContainer extends React.Component {
     this.setState({ isLoaded: false, error: null });
 
     // Set query parameters from state
-    this.setQueryString();
+    if (!document.querySelector('meta[http-equiv="X-Translated-By"]')) {
+      this.setQueryString();
+    }
 
     // Declare states and props
     const { currentPage, searchString, startDate, endDate } = this.state;

--- a/source/js/Module/Event/Components/FilterableEventsContainer.js
+++ b/source/js/Module/Event/Components/FilterableEventsContainer.js
@@ -122,7 +122,8 @@ class FilterableEventsContainer extends React.Component {
         categories: categoryIds,
         tags: tagIds,
         ageRange: ageRangeIds,
-      }
+      },
+      { pushState: true }
     );
       if(params.translate){
         location.hash = "#translate";


### PR DESCRIPTION
Quickfix deluxe!

Checks for meta element http-equiv="X-Translated-By" and disables push state.
Removes "back functionality" in translated clones of the page but loads the events.