### PR TITLE
fix: limit query when using pagination

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c72280fe0d62b68f01b6e71e5bab3bb",
+    "content-hash": "0ce7a1cd9a9642b45040b5000f462823",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -457,6 +457,76 @@
                 "source": "https://github.com/laravel/framework"
             },
             "time": "2019-06-20T13:13:59+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.12"
+            },
+            "time": "2022-04-13T08:02:27+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -1341,5 +1411,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/source/php/Module/Event/Event.php
+++ b/source/php/Module/Event/Event.php
@@ -233,7 +233,7 @@ class Event extends \Modularity\Module
         $currentPage = (get_query_var('paged')) ? get_query_var('paged') : 1;
 
         if ($numberOfPages > 1) {
-            for ($i = 1; $i < $numberOfPages; $i++) {
+            for ($i = 1; $i <= $numberOfPages; $i++) {
                 $href = $archiveUrl . '?' . $this->setQueryString($i). "#event";
 
                 $pagination[] = array(

--- a/source/php/Module/Event/Event.php
+++ b/source/php/Module/Event/Event.php
@@ -76,7 +76,6 @@ class Event extends \Modularity\Module
         // Taxonomies filter
         $data['categories'] = $this->getFilterableCategories($id);
         $data['groups'] = $this->getModuleGroups($id);
-        //$data['tags'] = $this->getFilterableTags($id);
         $data['tags'] = $this->getFilterableTags($id);
 
         // List module data
@@ -127,8 +126,8 @@ class Event extends \Modularity\Module
         }
 
         $max_per_page = (isset($fields->mod_event_limit)) ? $fields->mod_event_limit : 10;
-        $events = self::getEvents($module_id, 1);
-        $total_posts = count($events);  //Total number of posts returned
+        $posts = self::getEvents($module_id, 1, array('display_limit' => -1));
+        $total_posts = count($posts);
         $pages = ceil($total_posts / $max_per_page);
 
         if (isset($fields->mod_event_pagination_limit) && $fields->mod_event_pagination_limit >= 0
@@ -141,16 +140,16 @@ class Event extends \Modularity\Module
 
     /**
      * Get included Events
-     * @param  int  $module_id Module ID
-     * @param  int  $page      Pagination page number
-     * @param  bool $useLimit  True = limit by setting, false = get all
-     * @return array           Array with event objects
+     * @param  int    $module_id  Module ID
+     * @param  int    $page       Pagination page number
+     * @param  array  $params     Query params
+     * @return array              Array with event objects
      */
-    public function getEvents($module_id, $page = 1)
+    public function getEvents($module_id, $page = 1, $params = [])
     {
         $fields = json_decode(json_encode(get_fields($module_id)));
         $eventPagination = $fields->mod_event_pagination;
-        $display_limit = ($eventPagination == false && isset($fields->mod_event_limit)) ? $fields->mod_event_limit : -1;
+        $display_limit = isset($fields->mod_event_limit) ? $fields->mod_event_limit : -1;
         $days_ahead = isset($fields->mod_event_interval) ? $fields->mod_event_interval : 0;
 
         // Set start and end date
@@ -166,7 +165,7 @@ class Event extends \Modularity\Module
         $groups = $this->getModuleGroups($module_id);
 
         $taxonomies = (!empty($taxonomies)) ? $taxonomies : null;
-        $params = array(
+        $default_params = array(
             'start_date' => $start_date,
             'end_date' => $end_date,
             'display_limit' => $display_limit,
@@ -180,6 +179,7 @@ class Event extends \Modularity\Module
             'only_todays_date' => $mod_event_only_todays_date
         );
 
+        $params = array_merge($default_params, $params);
         $events = \EventManagerIntegration\Helper\QueryEvents::getEventsByInterval($params, $page);
 
         return $events;


### PR DESCRIPTION
Fixes bug when event-module is loading slow. Fixed it by limiting the query to only get events that will be shown and not everything.